### PR TITLE
Fix namespace creation to be inside if statement

### DIFF
--- a/run-backup.sh
+++ b/run-backup.sh
@@ -107,10 +107,10 @@ else
 
     fi
   fi
+  # now we no longer need to restore
+  $kubectl create ns $flagns >/dev/null 2>&1
 fi
 
-# now we no longer need to restore
-$kubectl create ns $flagns >/dev/null 2>&1
 
 
 ##############


### PR DESCRIPTION
Previously, it was outside. Since `kubectl create` returns an error if the resource already exists, this should only be in the `if` statement.